### PR TITLE
Updates to Omeka Bootstrap Theme

### DIFF
--- a/collections/browse.php
+++ b/collections/browse.php
@@ -3,7 +3,8 @@ $pageTitle = __('Browse Collections');
 echo head(array(
     'title' => $pageTitle,
     'bodyclass' => 'collections browse',
-)); ?>
+));
+?>
 <div id="primary">
     <div class="row page-header">
         <div class="col-xs-12">
@@ -22,14 +23,18 @@ echo head(array(
     ?>
     <div class="row">
         <div class="col-xs-12">
-            <div id="sort-links" class="pull-right">
-                <span class="sort-label label label-default"><?php echo __('Sort by:'); ?></span>
+            <div id="sort-links" class="input-group input-group-sm btn-group">
+                <span class="input-group-addon"><?php echo __('Sort by:'); ?></span>
+                <div class="input-group">
                     <?php
                         echo bootstrap_browse_sort_links($sortLinks, array(
-                            'list_attr' => array('id' => 'sort-links-list', 'class' => 'btn-group', 'role' => 'group', 'aria-label' => __('Sort by:')),
-                            'link_attr' => array('class' => 'btn btn-default btn-sm'),
+                            'list_tag'  => 'div',
+                            'list_attr' => array('class' => 'input-group-btn'),
+                            'link_tag'  => 'span',
+                            'link_attr' => array('class' => 'btn btn-default btn-sm', 'role' => 'button')
                         ));
                     ?>
+                </div>
             </div>
         </div>
     </div>
@@ -40,12 +45,15 @@ echo head(array(
             <div class="row">
                 <div class="col-sm-4">
                     <div class="collection-img">
-                        <?php $collectionImage = record_image('collection', 'square_thumbnail', array('class' => 'img-responsive')); ?>
-                        <?php if ($collectionImage): ?>
-                            <?php echo link_to_collection($collectionImage, array('class' => 'image')); ?>
-                        <?php else: ?>
-                            <div class="image none"></div>
-                        <?php endif; ?>
+                        <?php
+                            $collectionImage = record_image('collection', 'square_thumbnail', array('class' => 'img-responsive'));
+                            $noFile = '<img src="' . img('no-file.png') . '" class="img-rounded img-responsive img-thumbnail" alt="' . __('No file') . '" />';
+                            if ($collectionImage):
+                                echo link_to_collection($collectionImage, array('class' => 'image'));
+                            else:
+                                echo link_to_collection($noFile, array('class' => 'image none'));
+                            endif;
+                        ?>
                     </div>
                 </div>
                 <div class="col-sm-8">
@@ -61,7 +69,7 @@ echo head(array(
                 </div>
             </div>
             <div class="row">
-                <div class="col-xs-12">
+                <div class="col-sm-8 col-sm-offset-4">
                     <div class="element">
                         <div class="collection-description">
                             <?php echo text_to_paragraphs(metadata('collection', array('Dublin Core', 'Description'), array('snippet' => 150))); ?>
@@ -71,7 +79,7 @@ echo head(array(
                         <?php fire_plugin_hook('public_collections_browse_each', array('view' => $this, 'collection' => $collection)); ?>
                     </div>
                     <div>
-                        <p class="view-items-link-browse pull-right"><?php echo link_to_items_in_collection($text = 'View the items in this collection'); ?></p>
+                        <p class="view-items-link-browse"><?php echo link_to_items_in_collection($text = 'View the items in this collection'); ?></p>
 	                </div>
                 </div>
             </div>

--- a/collections/show.php
+++ b/collections/show.php
@@ -24,8 +24,8 @@
                 <div class="element-text">
                     <p><?php echo metadata('collection', array('Dublin Core', 'Contributor'), array('delimiter' => ', ')); ?></p>
                 </div>
+            </div>
             <?php endif; ?>
-         </div>
          </div>
     </div>
     <div class="row">

--- a/collections/show.php
+++ b/collections/show.php
@@ -34,12 +34,12 @@
         </div>
     </div>
     <div class="row">
-        <?php $noFile = '<img src="' . img('no-file.png') . '" class="img-rounded img-responsive img-polaroid" alt="' . __('No file') . '" />'; ?>
+        <?php $noFile = '<img src="' . img('no-file.png') . '" class="img-rounded img-responsive img-thumbnail" alt="' . __('No file') . '" />'; ?>
         <?php foreach(loop('items') as $item): ?>
         <div class="col-sm-3">
             <div class="well" style="text-align:center;">
                 <div><?php if (metadata($item, 'has files')):
-                    echo link_to_item(item_image('square_thumbnail', array('class' => 'img-rounded img-responsive img-polaroid')));
+                    echo link_to_item(item_image('square_thumbnail', array('class' => 'img-rounded img-responsive img-thumbnail')));
                 else:
                     echo link_to_item($noFile, array('class' => 'image none'), 'show', $item);
                 endif; ?>

--- a/common/breadcrumb.php
+++ b/common/breadcrumb.php
@@ -66,7 +66,8 @@ if (is_current_url('/')):
                                 if (empty($collection)) {
                                     $breadcrumbs[] = link_to_items_browse(__('Browse'));
                                 } else {
-                                    $breadcrumbs[] = link_to_items_in_collection(null, array(), 'browse', $collection);
+                                    $breadcrumbs[] = link_to('collections', 'browse', __('Collections'));
+                                    $breadcrumbs[] = link_to_collection_for_item($collection->getProperty('display_title'));
                                 }
                             } elseif ($mode == 'type') {
                                 $itemType = $item->getItemType();
@@ -117,7 +118,8 @@ if (is_current_url('/')):
                         if (empty($collection)) {
                             $breadcrumbs[] = link_to_items_browse(__('Browse'));
                         } else {
-                            $breadcrumbs[] = link_to_items_in_collection(null, array(), 'browse', $collection);
+                            $breadcrumbs[] = link_to('collections', 'browse', __('Collections'));
+                            $breadcrumbs[] = link_to_collection_for_item($collection->getProperty('display_title'));
                         }
                     } elseif ($mode == 'type') {
                         $itemType = $item->getItemType();
@@ -183,6 +185,17 @@ if (is_current_url('/')):
                             $breadcrumbs[] = link_to('exhibits', 'browse', __('Exhibits'));
                             $breadcrumbs[] = exhibit_builder_link_to_exhibit();
                             $breadcrumbs = array_merge($breadcrumbs, bootstrap_breadcrumb_exhibit_page());
+                            break;
+                        case 'show-item':
+                            if (!isset($item) || !$item) {
+                                $item = get_current_record('item');
+                            }
+                            $breadcrumbs[] = link_to('exhibits', 'browse', __('Exhibits'));
+                            $breadcrumbs[] = exhibit_builder_link_to_exhibit();
+                            // Appends hierarchical links of all parent exhibit pages for current item to the breadcrumb array
+                            $breadcrumbs   = array_merge($breadcrumbs, bootstrap_breadcrumb_exhibit_page(related_exhibit_page($item), true));
+                            // Gets us the Item name text for the last part of the breadcrumb trail, removes hyperlink (strip_tags) to item
+                            $breadcrumbs[] = strip_tags(exhibit_builder_link_to_exhibit_item());
                             break;
                     endswitch;
                     break;

--- a/common/header.php
+++ b/common/header.php
@@ -64,7 +64,6 @@
         <em><?php echo $displayBanner; ?></em>
     </span>
     <?php endif; ?>
-    <div>
     <header id="header" role="banner" class="container">
         <div class="row">
             <div id="site-title" class="col-sm-6">

--- a/common/show-selected-metadata.php
+++ b/common/show-selected-metadata.php
@@ -1,0 +1,155 @@
+<div class="row">
+    <div class="col-md-6">
+        <!-- Item Description -->
+        <div class="row">
+            <div class="col-xs-12">
+                <h4><span class="fa fa-thumb-tack fa-lg"></span> <?php echo __('Description'); ?></h4>
+                <?php if ($itemDescription = metadata($item,array('Dublin Core','Description'))): ?>
+                    <p class="lead"><?php echo $itemDescription; ?></p>
+                <?php else: ?>
+                    <p class="alert"><strong><?php echo __('Sorry!'); ?></strong> <?php echo __('No description recorded yet.'); ?></p>
+                <?php endif; ?>
+            </div>
+        </div>
+
+        <!-- If the item belongs to a collection, the following creates a link to that collection. -->
+        <?php if (get_collection_for_item($item)): ?>
+        <div class="row"><div class="col-xs-12">
+            <hr />
+            <div id="collection">
+                <h4 style="display:inline"><span class="glyphicon glyphicon-book"></span> <?php echo __('Collection'); ?>: </h4>
+                <h4 style="display:inline"><?php echo link_to_collection_for_item(); ?></h4>
+            </div>
+        </div></div>
+        <?php endif; ?>
+
+        <div class="row">
+            <div class="col-xs-12">
+            <hr />
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-md-4">
+            <!-- Item Date Information -->
+                <h4><span class="fa fa-calendar fa-lg"></span> <?php echo __('Date'); ?></h4>
+                <?php if ($itemDate = metadata($item,array('Dublin Core','Date'))): // TODO: create a date format function or filter...?>
+                    <div><?php echo $itemDate; ?></div>
+                <?php else: ?>
+                    <div><?php echo __('None recorded'); ?></div>
+                <?php endif; ?>
+            </div>
+            <div class="col-md-4">
+            <!-- Item Creator Information -->
+                <h4><span class="fa fa-user fa-lg"></span> <?php echo __('Creator'); ?></h4>
+                <div>
+                <?php if ($itemCreator = metadata($item, array('Dublin Core', 'Creator'))): ?>
+                    <?php echo $itemCreator; ?>
+                <?php else: ?>
+                    <?php echo __('None recorded'); ?>
+                <?php endif; ?>
+                </div>
+            </div>
+            <div class="col-md-4">
+            <!-- Item Recipient Information (if available) -->
+              <h4><span class="fa fa-archive fa-lg"></span> <?php echo __('Source'); ?></h4>
+                <div>
+                <?php if ($itemCreator = metadata($item,array('Dublin Core','Source'))): ?>
+                    <?php echo $itemCreator; ?>
+                <?php else: ?>
+                    <?php echo __('None recorded'); ?>
+                <?php endif; ?>
+                </div>
+            </div>
+        </div>
+        <div class="row"><hr />
+            <!-- Subject -->
+            <div class="col-md-4">
+                 <h4><span class="fa fa-book fa-lg"></span><?php echo __(' Subject'); ?></h4>
+                <?php if ($itemCreator = metadata($item,array('Dublin Core','Subject'))): ?>
+                    <?php echo $itemCreator; ?>
+                <?php else: ?>
+                    <?php echo __('None recorded'); ?>
+                <?php endif; ?>
+            </div>
+            <!-- Identifier -->
+            <div class="col-md-4">
+                <h4><span class="fa fa-bookmark fa-lg"></span><?php echo __(' Identifier'); ?></h4>
+                <?php if ($itemCreator = metadata($item,array('Dublin Core','Identifier'))): ?>
+                    <?php echo $itemCreator; ?>
+                <?php else: ?>
+                    <?php echo __('None recorded'); ?>
+                <?php endif; ?>
+            </div>
+            <!-- Contributor -->
+            <div class="col-md-4">
+                <h4><span class="fa fa-university fa-lg"></span><?php echo __(' Contributor'); ?></h4>
+                <?php if ($itemCreator = metadata($item,array('Dublin Core','Contributor'))): ?>
+                    <?php echo $itemCreator; ?>
+                <?php else: ?>
+                    <?php echo __('None recorded'); ?>
+                <?php endif; ?>
+            </div>
+        </div>
+        <!-- If the item belongs to a collection, the following creates a link to that collection. -->
+
+        <!-- The following prints a list of all tags associated with the item -->
+        <div class="row">
+            <div class="col-xs-12">
+                <hr />
+                <h4><span class="fa fa-tags fa-large"></span> Tags</h4>
+                <div class="tags well well-small">
+                    <?php if (tag_string($item) != null) {
+                        echo tag_string($item); }
+                        else {
+                        echo __('No tags recorded for this item.');
+                        }
+                    ?>
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <!-- Rights -->
+                <div class="col-xs-12"><hr />
+                    <h4><span class="fa fa-copyright fa-lg"></span><?php echo __(' Rights'); ?></h4>
+                    <?php if ($itemCreator = metadata($item,array('Dublin Core','Rights'))): ?>
+                        <?php echo $itemCreator; ?>
+                    <?php else: ?>
+                        <?php echo __('None recorded'); ?>
+                    <?php endif; ?>
+                </div>
+        </div>
+         <div class="row">
+            <div class="col-xs-12">
+                <hr />
+                <!-- The following prints a citation for this item. -->
+                <h4><span class="fa fa-retweet fa-lg"></span> <?php echo __('Citation'); ?></h4>
+                <div class="element-text"><?php echo metadata($item,'citation',array('no_escape' => true)); ?></div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-xs-12">
+                <hr />
+                <?php fire_plugin_hook('public_items_show', array('view' => $this, 'item' => $item)); ?>
+            </div>
+        </div>
+    </div>
+    <!-- The following returns all of the files associated with an item. -->
+    <div id="itemfiles" class="col-md-6">
+        <?php if (metadata('item', 'has files')): ?>
+        <!-- <h3><?php echo __('Files'); ?></h3> -->
+        <div class="element-text"><?php echo files_for_item(
+            //options
+            array(
+                'imageSize' => 'fullsize',
+                'linkToFile' => true,
+                'linkToMetadata'=>false,
+                'imgAttributes' => array('class' => 'img-responsive'),
+            ),
+            // wrapper
+            array('class' => 'file-image'),
+            null);
+        ?></div>
+        <?php endif; ?>
+    </div>
+</div>

--- a/css/style.css
+++ b/css/style.css
@@ -114,6 +114,17 @@ a:hover {
 #logo {
     margin: 10px 0 10px 65px;
 }
+
+/* Taken from DPLA CSS to fix specific plugin layouts */
+.plugin-content, .plugin-content .item-file, .plugin-content .openseadragon, .plugin-content .zoomit {
+    height: 420px;
+}
+.openseadragon_viewer, .zoomit_viewer {
+    width: 100%;
+    height: 420px;
+    background: #000;
+}
+
 @media only screen and (max-width: 768px) {
     #logo {
         margin: 10px 0 10px 0px;
@@ -478,6 +489,9 @@ footer a {
 #sort-links-list {
     padding-left: 12px;
 }
+#sort-links {
+    margin-bottom:20px;
+}
 .asc a::after {
     content: " ";
 }
@@ -506,7 +520,7 @@ footer a {
 #search-filters li {
     background: rgba(0, 0, 0, 0) url("../images/search.png") no-repeat scroll 0 2px;
     display: inline-block;
-    margin: 0 30px 20px 0;
+    margin: 0 30px 0 0;
     padding: 0 0 0 21px;
 }
 .bs-callout + #pagination-top,

--- a/css/style.css
+++ b/css/style.css
@@ -336,6 +336,7 @@ margin-right: 5px;
 }
 .popover-form label {
     font-weight: 400;
+    float:none;
 }
 .popover-form legend {
     font-size: inherit;

--- a/items/browse.php
+++ b/items/browse.php
@@ -42,14 +42,18 @@ echo head(array(
     ?>
     <div class="row">
         <div class="col-xs-12">
-            <div id="sort-links" class="pull-right">
-                <span class="sort-label label label-default"><?php echo __('Sort by:'); ?></span>
+            <div id="sort-links" class="input-group input-group-sm btn-group">
+                <span class="input-group-addon"><?php echo __('Sort by:'); ?></span>
+                <div class="input-group">
                     <?php
                         echo bootstrap_browse_sort_links($sortLinks, array(
-                            'list_attr' => array('id' => 'sort-links-list', 'class' => 'btn-group', 'role' => 'group', 'aria-label' => __('Sort by:')),
-                            'link_attr' => array('class' => 'btn btn-default btn-sm'),
+                            'list_tag'  => 'div',
+                            'list_attr' => array('class' => 'input-group-btn'),
+                            'link_tag'  => 'span',
+                            'link_attr' => array('class' => 'btn btn-default btn-sm', 'role' => 'button')
                         ));
                     ?>
+                </div>
             </div>
         </div>
     </div>
@@ -62,7 +66,7 @@ echo head(array(
                 <div class="item">
                 <div class="carousel-img" style="text-align: center">
                 <?php if (metadata($item, 'has thumbnail')): ?>
-                    <?php echo link_to_item(item_image('thumbnail', array('class' => 'img-responsive img-polaroid')), null, null, $item); ?>
+                    <?php echo link_to_item(item_image('thumbnail', array('class' => 'img-responsive img-thumbnail')), null, null, $item); ?>
                 <?php else: ?>
                     <div class="image none"></div>
                  <?php endif; ?>

--- a/items/show.php
+++ b/items/show.php
@@ -6,7 +6,7 @@ echo head(array(
 ));
 ?>
 <div id="primary">
-    <div class="row">
+    <div class="row form-group">
         <div class="col-xs-12">
             <nav class="pager">
                 <ul>
@@ -92,8 +92,9 @@ else:
         <!-- The following returns all of the files associated with an item. -->
         <div id="itemfiles" class="col-md-6">
             <?php if (metadata('item', 'has files')): ?>
-            <!-- <h3><?php echo __('Files'); ?></h3> -->
-            <div class="element-text"><?php echo files_for_item(
+            <h3><?php echo metadata('item', 'file_count') == 1 ? __('File') : __('Files'); ?></h3>
+            <div class="element-text"><?php echo custom_files_for_item(
+                // This might be easier for future customization: https://omeka.org/codex/Display_Specific_Metadata_for_an_Item_File
                 //options
                 array(
                     'imageSize' => 'fullsize',
@@ -110,7 +111,7 @@ else:
     </div>
 <?php endif; ?>
     <br />
-    <div class="row">
+    <div class="row form-group">
         <div class="col-xs-12">
             <nav class="pager">
                 <ul>

--- a/items/single.php
+++ b/items/single.php
@@ -11,7 +11,7 @@
             array('class' => 'image'), 'show', $item
         );
     else:
-        $noFile = '<img src="' . img('no-file.png') . '" class="img-rounded img-responsive img-polaroid" alt="' . __('No file') . '" />';
+        $noFile = '<img src="' . img('no-file.png') . '" class="img-rounded img-responsive img-thumbnail" alt="' . __('No file') . '" />';
         echo link_to_item($noFile, array('class' => 'image none'), 'show', $item);
     endif; ?>
     </div>

--- a/search/search-form.php
+++ b/search/search-form.php
@@ -52,7 +52,7 @@
     <?php else: ?>
         <?php echo $this->formHidden('query_type', $filters['query_type']); ?>
         <?php foreach ($filters['record_types'] as $type): ?>
-        <?php echo $this->formHidden('record_types[]', $type); ?>
+        <?php echo $this->formHidden("record_types[{$type}]", $type); ?>
         <?php endforeach; ?>
     <?php endif; ?>
 </form>


### PR DESCRIPTION
`collections/browse.php`:
- Updated sort-links to more closely match Bootstrap styling
- When no associated image for a collection, now displays the
`no-file.png` replacement image
- Updated alignment of description and link to collection so it
left-aligns with collection title instead of wraps below or aligns
right, respectively

`collections/show.php`:
- Updated old bootstrap class of `img-polaroid` with bootstrap3 class of
`img-thumbnail`

`common/breadcrumb.php`:
- Updated breadcrumbs to provide a more correct breadcrumb trail
depending on content and settings
- Added Exhibit Builder `show-item` breadcrumb capability -- full
breadcrumb to first matching Exhibit related to currently viewed item
(if item belongs to multiple exhibits it just uses the first returned
Exhibit from the database since we can't know, via PHP, which Exhibit
the user came from)

`common/header.php`:
- Removed extra orphaned `<div>`

`common/show-selected-metadata.php`:
- Added this file for the `items/show.php` rendering, file seemed to be
missing from repo

`css/style.css`:
- Added helpful classes for compatibility with OpenSeaDragon and Zoomit
Omeka plugins
- Added custom theme styling for `#sort-links` due to change in
`collections/browse.php` to use Bootstrap styling of sort links
- Changed `#search-filters li` styling to better match other theme
content styles

`custom.php`:
- Added optional parameter (and functionality with the parameter) to
`bootstrap_breadcrumb_exhibit_page()` function to allow for the last
element in the breadcrumb trail to also be hyperlinked (used for Exhibit
Item Show page)
- Added `custom_files_for_item()` and `custom_file_markup()` to allow
images to be displayed with HTML5 `<figure>` element markup and
associated filename
- Added `related_exhibit_page()` function as helper to item-show
breadcrumb creation

`items/browse.php`:
- Updated sort-links to more closely match Bootstrap styling
- Updated old bootstrap class of `img-polaroid` with bootstrap3 class of
`img-thumbnail`

`items/show.php`:
- Added `form-group` class to DIV as a hackish fix for better style
matching in two places
- Changed "Files" header to "File" OR "Files" depending on number of
matching items; implemented custom_files_for_item function from updated
theme's `custom.php`

`items/single.php`:
- When no associated image for a collection, now displays the
`no-file.png` replacement image